### PR TITLE
fix: replace all /open-source/ links with /docs/orama-js/ and use redirects

### DIFF
--- a/content/docs/orama-js/internals/components.mdx
+++ b/content/docs/orama-js/internals/components.mdx
@@ -197,7 +197,7 @@ To customize the index used by Orama, provide an object which has at least the f
 - `searchByWhereClause`: A function that searches in boolean and numeric indexes and returns a list of matching IDs. It receives the following arguments:
   - `context`: A search context with various useful information about the search.
   - `index`: The index.
-  - `filters`: An object where keys are the properties to match and the values are search operators as described in the [filters](/open-source/usage/search/filters) page.
+  - `filters`: An object where keys are the properties to match and the values are search operators as described in the [filters](/docs/orama-js/search/filters) page.
 - `getSearchableProperties`: A function that returns a list of all searchable properties in the index. It receives the index as the only argument.
 - `getSearchablePropertiesWithTypes`: A function that returns an object where keys are the searchable properties in the index and the values are the type of the index for a property. It receives the index as the only argument.
 - `load`: A function that deserializes an index from a JavaScript object. It receives The document IDs mapper and a JavaScript object as its only argument and must return an index.

--- a/content/docs/orama-js/plugins/index.mdx
+++ b/content/docs/orama-js/plugins/index.mdx
@@ -11,4 +11,4 @@ That said, the Orama core team is working on some official plugins to support sp
 
 All the official plugins' source code is hosted under the [Orama](https://github.com/oramasearch/orama) monorepo, in the [`packages`](https://github.com/oramasearch/orama/tree/main/packages) directory.
 
-If you want to learn more about writing your own plugins, read the guide [available here](/open-source/plugins/writing-your-own-plugins).
+If you want to learn more about writing your own plugins, read the guide [available here](/docs/orama-js/plugins/writing-your-own-plugins).

--- a/content/docs/orama-js/plugins/plugin-docusaurus.mdx
+++ b/content/docs/orama-js/plugins/plugin-docusaurus.mdx
@@ -53,7 +53,7 @@ plugins: [
 ];
 ```
 
-For more information about the props you can use on the analytics plugin, check the [Analytics plugin](/open-source/plugins/plugin-analytics) section.
+For more information about the props you can use on the analytics plugin, check the [Analytics plugin](/docs/orama-js/plugins/plugin-analytics) section.
 
 #### Searchbox & Search Button
 

--- a/content/docs/orama-js/search/filters.mdx
+++ b/content/docs/orama-js/search/filters.mdx
@@ -172,4 +172,4 @@ Starting from Orama `v2.0.0`, you can perform geosearch queries.
 
 Even though the APIs are very simple, we decided to dedicate a separate section for them. This lets us explain the concepts behind the geosearch and how it works with more details.
 
-[Read more about geosearch](/open-source/usage/search/geosearch)
+[Read more about geosearch](/docs/orama-js/search/geosearch)

--- a/content/docs/orama-js/search/hybrid-search.mdx
+++ b/content/docs/orama-js/search/hybrid-search.mdx
@@ -7,9 +7,9 @@ Hybrid search is an Orama feature that allows you to perform full-text and vecto
 <Callout title="Generating Embeddings">
 In this page, we will assume that you already have the embeddings for your documents.
 
-If you don't, you can use the [Plugin Embeddings](/open-source/plugins/plugin-embeddings) to generate them directly offline and on-device at insert and search time.
+If you don't, you can use the [Plugin Embeddings](/docs/orama-js/plugins/plugin-embeddings) to generate them directly offline and on-device at insert and search time.
 
-If you're running Orama in a memory-constrained environment, you can also use the [Plugin Secure Proxy](/open-source/plugins/plugin-secure-proxy) to generate embeddings on the fly using the OpenAI API directly from the client-side.
+If you're running Orama in a memory-constrained environment, you can also use the [Plugin Secure Proxy](/docs/orama-js/plugins/plugin-secure-proxy) to generate embeddings on the fly using the OpenAI API directly from the client-side.
 </Callout>
 
 ## Performing Hybrid Search
@@ -60,7 +60,7 @@ const results = search(db, {
 ```
 
 <Callout title="Simplify it!">
-When running vector search using the [secure proxy](/open-source/plugins/plugin-embeddings) or [embeddings](/open-source/plugins/plugin-secure-proxy) plugins, you won't need to explicitly pass the `vector` configuration. Just run a simple search query!
+When running vector search using the [secure proxy](/docs/orama-js/plugins/plugin-embeddings) or [embeddings](/docs/orama-js/plugins/plugin-secure-proxy) plugins, you won't need to explicitly pass the `vector` configuration. Just run a simple search query!
 
 ```js
 const results = search(db, {

--- a/content/docs/orama-js/search/preflight.mdx
+++ b/content/docs/orama-js/search/preflight.mdx
@@ -50,7 +50,7 @@ By using a `preflight` request, you will be able to retrieve facets and a total 
 
 ## How is that useful?
 
-Preflight requests are particularly useful in certain situations, like when spawned right before a query with a certain [threshold](/open-source/usage/search/threshold).
+Preflight requests are particularly useful in certain situations, like when spawned right before a query with a certain [threshold](/docs/orama-js/search/threshold).
 
 For example, let's say you have a large database of 50,000 products. If a user searches for a very rare product, you may end up with just a few results if the threshold is set to `0` (exact match).
 
@@ -62,4 +62,4 @@ By running a preflight search, you will be able to programmatically set a differ
 - **The preflight search returns 10 results**. You can set the threshold to `0.2`, returning the 10 results + 20% of the fuzzy-matched results.
 - **The preflight search returns 100 results**. You can set the threshold to `0`, returning only the 100 exact-matched results.
 
-Read the [threshold](/open-source/usage/search/threshold) documentation for more information on how the `threshold` parameter affects search results.
+Read the [threshold](/docs/orama-js/search/threshold) documentation for more information on how the `threshold` parameter affects search results.

--- a/content/docs/orama-js/search/threshold.mdx
+++ b/content/docs/orama-js/search/threshold.mdx
@@ -87,7 +87,7 @@ const results = search(db, {
 In this case, the `threshold` property is set to `0`, which means that only the document containing the `"slim fit"` keywords will be returned.
 This applies to all the document properties; if a keyword is found in a property, and another keyword is found in a different property, the document will be returned.
 
-You can boost the results depending on where a property is found using the [field boosting](/open-source/usage/search/fields-boosting) API.
+You can boost the results depending on where a property is found using the [field boosting](/docs/orama-js/search/fields-boosting) API.
 
 ### Setting the threshold to a value between `0` and `1`
 

--- a/content/docs/orama-js/search/vector-search.mdx
+++ b/content/docs/orama-js/search/vector-search.mdx
@@ -4,14 +4,14 @@ description: Learn how to perform vector search using Orama.
 ---
 Being a vector database, Orama allows you to perform vector search natively.
 
-To perform search through vectors, you need to correctly configure your Orama schema, as described in the [create page](/open-source/usage/create).
+To perform search through vectors, you need to correctly configure your Orama schema, as described in the [create page](/docs/orama-js/usage/create).
 
 <Callout title="Generating Embeddings">
 In this page, we will assume that you already have the embeddings for your documents.
 
-If you don't, you can use the [Plugin Embeddings](/open-source/plugins/plugin-embeddings) to generate them directly offline and on-device at insert and search time.
+If you don't, you can use the [Plugin Embeddings](/docs/orama-js/plugins/plugin-embeddings) to generate them directly offline and on-device at insert and search time.
 
-If you're running Orama in a memory-constrained environment, you can also use the [Plugin Secure Proxy](/open-source/plugins/plugin-secure-proxy) to generate embeddings on the fly using the OpenAI API directly from the client-side.
+If you're running Orama in a memory-constrained environment, you can also use the [Plugin Secure Proxy](/docs/orama-js/plugins/plugin-secure-proxy) to generate embeddings on the fly using the OpenAI API directly from the client-side.
 </Callout>
 
 ## Performing Vector Search
@@ -69,7 +69,7 @@ const results = search(db, {
 ```
 
 <Callout title="Simplify it!">
-When running vector search using the [secure proxy](/open-source/plugins/plugin-embeddings) or [embeddings](/open-source/plugins/plugin-secure-proxy) plugins, you won't need to explicitly pass the `vector` configuration. Just run a simple search query!
+When running vector search using the [secure proxy](/docs/orama-js/plugins/plugin-embeddings) or [embeddings](/docs/orama-js/plugins/plugin-secure-proxy) plugins, you won't need to explicitly pass the `vector` configuration. Just run a simple search query!
 
 ```js
 const results = search(db, {

--- a/content/docs/orama-js/supported-languages/index.mdx
+++ b/content/docs/orama-js/supported-languages/index.mdx
@@ -11,7 +11,7 @@ At the time of writing, Chinese (Mandarin) and Japanese are the only exception, 
 
 Since Chinese and Japanese logograms follow different rules than other alphabets, you will need to import a dedicated tokenizer for it.
 
-Read more here about Chinese [here](/open-source/supported-languages/using-chinese-with-orama) and about Japanese [here](/open-source/supported-languages/using-japanese-with-orama).
+Read more here about Chinese [here](/docs/orama-js/supported-languages/using-chinese-with-orama) and about Japanese [here](/docs/orama-js/supported-languages/using-japanese-with-orama).
 </Callout>
 
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,11 +5,12 @@ const withMDX = createMDX()
 /** @type {import('next').NextConfig} */
 const config = {
   reactStrictMode: true,
-  async rewrites() {
+  async redirects() {
     return [
       {
         source: '/open-source/:path*',
-        destination: '/orama-js/:path*',
+        destination: '/docs/orama-js/:path*',
+        permanent: true,
       },
     ]
   }


### PR DESCRIPTION
##  Problem Description
The documentation contains multiple `/open-source/` path links that result in 404 errors. Although a `rewrites()` configuration was previously added, it only affects server routing and doesn't fix static links in MDX files.

##  Results
- Updated all internal MDX links from /open-source/ to /docs/orama-js/
- Changed rewrites() to redirects() with permanent 301 redirects
- Fixed incorrect path /docs/orama-js/create to /docs/orama-js/usage/create
- Ensures all internal links work correctly and external old links redirect properly